### PR TITLE
add support for custom names

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Live Demo: https://circa10a.github.io/monitor/
 - Follow the prompts!
 
 ## Usage
-- Have a text file with hostnames or ip addresses (optional: if port is desired seperate by comma. example: www.google.com, 80)
+- Have a text file with hostnames or ip addresses (optional: if port and name are desired separate by comma. example: www.google.com, 80, Google. Custom name requires a port.)
 - Update the python script (variable at the top) with the path/name of your file with hostnames and output file path.(default hostames= hostnames.txt   default output= index.html)
 - Run `python report.py`
 - Ensure that you place the output HTML file in the project directory so it can find its web dependencies
@@ -48,11 +48,11 @@ Live Demo: https://circa10a.github.io/monitor/
 - `docker run -d -p 80:80 -v ~/path/to/your/hostnames.txt:/usr/share/nginx/html/hostnames.txt --name monitor circa10a/device-monitor-dashboard`
 
 ### Build your own docker image:
-- `git clone https://github.com/circa10a/Device-Monitor-Dashboard.git` 
+- `git clone https://github.com/circa10a/Device-Monitor-Dashboard.git`
 - `cd Device-Monitor-Dashboard`   
 - Edit your hostnames.txt file add your website, servers, switches, devices, etc.  
 - `docker build -t myrepo/monitor .`  
-- `docker run --name device-monitor -d -p 80:80 myrepo/monitor` 
+- `docker run --name device-monitor -d -p 80:80 myrepo/monitor`
 ```diff
 - Known issue: Docker for Mac pings any address and returns success giving false results.
 ```

--- a/hostnames.txt
+++ b/hostnames.txt
@@ -1,4 +1,4 @@
-www.github.com,80
-www.reddit.com, 443
-www.google.com
-www.apple.com
+www.github.com,80, GitHub
+www.reddit.com, 443, Reddit
+www.google.com, Google
+www.apple.com, Apple

--- a/report.py
+++ b/report.py
@@ -48,7 +48,7 @@ def parsehost(hostfile):
             servername = servername.replace(" ", "")
             # check if port is defined
             if ',' in servername:
-                # create list that is servername, port number
+                # create list that is servername, port number, custom name
                 servername = servername.split(",")
                 hostname = servername[0]
                 try:
@@ -56,9 +56,16 @@ def parsehost(hostfile):
                 except:
                     print "%s Port: %s is not a number!" % (hostname, servername[1])
                     sys.exit()
-                servers.append({"hostname":hostname, "port":port})
+
+                try:
+                    name = servername[2]
+                except:
+                    print "No name"
+                    sys.exit()
+
+                servers.append({"hostname":hostname, "port":port, "name":name})
             else:
-                servers.append({"hostname":servername, "port":None})
+                servers.append({"hostname":servername, "port":None, "name":None})
     return servers
 
 def createhtml(output_file_name, template_file, host_dict):
@@ -112,7 +119,7 @@ def createhtml(output_file_name, template_file, host_dict):
     for h in host_dict:
         if h["status"] == "up" and h["port"] != None:
             html_file.write("\n		<tr>\n")
-            html_file.write("		<td onClick=\"window.open(\'http://" + (h["hostname"]) + ":" + str(h["port"]) + "\')\";" + "class=\"text-left\">" + (h["hostname"]) + " port: " + str(h["port"]) + "</td>")
+            html_file.write("		<td onClick=\"window.open(\'http://" + (h["hostname"]) + ":" + str(h["port"]) + "\')\";" + "class=\"text-left\">" + (h["name"]) + ":" + str(h["port"]) + "</td>")
             html_file.write("\n		<td><div class=\"led-green\"></div></td>")
         elif h["status"] == "up":
             html_file.write("\n		<tr>\n")


### PR DESCRIPTION
Enables a custom name to be displayed in the report.

Defined in hostnames.txt as "www.google.com, 80, Google"

Requires a port number.